### PR TITLE
Add SF CLI authentication with auto-detection and fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,16 @@ The codebase follows a clean four-layer architecture with pluggable authenticati
 - Uses PKCE (Proof Key for Code Exchange) for enhanced security
 
 **Query Execution Flow:**
-1. Submit SQL query via POST to get `queryId`
+1. Submit SQL query via POST (with optional `sqlParameters`) to get `queryId`
 2. Poll query status with long-polling (`waitTimeMs=10000`) until completion
 3. Retrieve results via pagination if `rowCount > initial rows returned`
 4. Aggregate all pages into single response
+
+**Parameterized Queries:**
+- `run_query()` accepts an optional `sql_parameters` list for safe value binding
+- Parameters use `:paramName` placeholders in SQL, resolved server-side by Data Cloud
+- Format: `[{"name": "paramName", "value": "someValue"}]` (optional `"type"` key)
+- Used by `describe_table()` to safely pass the table name without string interpolation
 
 **Workload Management:**
 - Default workload name: `"data-360-mcp-query-oss"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,187 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+<!-- Test change for SSH signing -->
+
+## Project Overview
+
+This is a Model Context Protocol (MCP) server that provides integration between Cursor IDE and Salesforce Data Cloud. It exposes tools for executing SQL queries, listing tables, and describing table structures through the MCP protocol using the FastMCP framework.
+
+## Setup and Development
+
+### Installation
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### Running the Server
+
+**Option 1: Using SF CLI Authentication (Recommended)**
+```bash
+# Prerequisites: Authenticate with SF CLI
+sf org login web --alias myorg
+
+# Set required environment variable
+export SF_ORG_ALIAS="myorg"
+
+# Optional environment variables
+export DEFAULT_LIST_TABLE_FILTER="%"  # default, SQL LIKE pattern
+
+# Run the server
+python server.py
+```
+
+**Option 2: Using OAuth PKCE Authentication**
+```bash
+# Set required environment variables
+export SF_CLIENT_ID="your_client_id"
+export SF_CLIENT_SECRET="your_client_secret"
+
+# Optional environment variables
+export SF_LOGIN_URL="login.salesforce.com"  # default
+export SF_CALLBACK_URL="http://localhost:55556/Callback"  # default
+export DEFAULT_LIST_TABLE_FILTER="%"  # default, SQL LIKE pattern
+
+# Run the server
+python server.py
+```
+
+### Testing Individual Components
+
+```bash
+# Test the Data Cloud SQL client directly
+python connect_api_dc_sql.py
+
+# This will prompt for OAuth authentication and run a test query
+```
+
+## Architecture
+
+### Four-Layer Design
+
+The codebase follows a clean four-layer architecture with pluggable authentication:
+
+1. **MCP Server Layer** (`server.py`)
+   - Entry point for the MCP server using FastMCP framework
+   - Defines three MCP tools: `query()`, `list_tables()`, `describe_table()`
+   - Uses authentication abstraction via `auth_provider` interface
+   - All SQL uses PostgreSQL dialect
+
+2. **Authentication Abstraction Layer**
+   - `auth_interface.py`: Defines `AuthProvider` protocol with `get_token()`, `get_instance_url()`, and `is_available()` methods
+   - `auth_factory.py`: Auto-detection logic that selects appropriate authentication method
+   - Implements authentication priority: SF CLI → OAuth → Error with setup instructions
+
+3. **Authentication Implementations**
+   - **SF CLI Authentication** (`sf_cli_auth.py`):
+     - Uses `sf org display --target-org <alias> --json` subprocess to obtain tokens
+     - Caches tokens for 5 minutes to reduce overhead
+     - Validates SF CLI availability and org authentication
+   - **OAuth PKCE Authentication** (`oauth.py`):
+     - `OAuthConfig`: Loads configuration from environment variables
+     - `OAuthSession`: Manages access token lifecycle with browser-based flow
+     - Implements OAuth2 with PKCE extension for security
+     - Auto-refreshes tokens after 110-minute expiration
+     - Opens browser for user authentication via local HTTP callback server
+
+4. **Data Cloud API Layer** (`connect_api_dc_sql.py`)
+   - `run_query()`: Core query execution against Salesforce Data Cloud Query API
+   - Uses Salesforce REST API v63.0 endpoint: `/services/data/v63.0/ssot/query-sql`
+   - Handles asynchronous query execution with polling
+   - Implements automatic pagination for large result sets (default: 100K rows per batch)
+   - Returns structured response: `{"data": [...], "metadata": [...]}`
+   - Works with any `AuthProvider` implementation via protocol
+
+### Key Patterns
+
+**Authentication Auto-Detection:**
+- Factory pattern with automatic fallback
+- Priority: SF CLI (if `SF_ORG_ALIAS` set) → OAuth (if credentials set) → Error
+- Validates authentication during initialization with clear error messages
+- All authentication providers implement the same `AuthProvider` protocol
+
+**SF CLI Token Management:**
+- Tokens cached for 5 minutes (balance between performance and freshness)
+- Subprocess timeout: 120 seconds
+- Comprehensive error messages guide users to `sf org login web`
+- Validates SF CLI JSON output structure before using
+
+**OAuth Token Management:**
+- Tokens are lazily initialized on first use
+- `ensure_access()` checks expiration and re-authenticates if needed
+- Browser-based OAuth flow opens automatically when token is missing/expired
+- Uses PKCE (Proof Key for Code Exchange) for enhanced security
+
+**Query Execution Flow:**
+1. Submit SQL query via POST to get `queryId`
+2. Poll query status with long-polling (`waitTimeMs=10000`) until completion
+3. Retrieve results via pagination if `rowCount > initial rows returned`
+4. Aggregate all pages into single response
+
+**Workload Management:**
+- Default workload name: `"data-360-mcp-query-oss"`
+- Workload name can be customized via `workload_name` parameter in `run_query()`
+- Workloads are used for query resource management in Salesforce Data Cloud
+
+## MCP Configuration in Cursor
+
+The server is designed to be configured in Cursor's MCP settings with these auto-approve tools for better UX:
+- `suggest_table_and_fields` (if implemented)
+- `describe_table`
+- `list_tables`
+
+See README.md for full Cursor configuration example.
+
+## Important Implementation Details
+
+### Authentication Methods
+
+**SF CLI Authentication:**
+- Requires Salesforce CLI installed: https://developer.salesforce.com/tools/salesforcecli
+- Requires authenticated org: `sf org login web --alias <alias>`
+- Set `SF_ORG_ALIAS` environment variable
+- Token caching: 5 minutes (reduces subprocess overhead)
+- No Connected App setup required
+
+**OAuth PKCE Authentication:**
+- Requires Salesforce Connected App with:
+  - PKCE enabled
+  - Callback URL matching `SF_CALLBACK_URL` exactly
+  - Required OAuth scopes: `api`, `cdp_query_api`, `cdp_profile_api`
+  - IP restrictions relaxed (set to "Relax IP restrictions")
+  - Avoid using port 55555 (use 55556 or other port)
+- See CONNECTED_APP_SETUP.md for complete setup instructions
+
+**Auto-Detection Priority:**
+1. If `SF_ORG_ALIAS` is set: Try SF CLI, fallback to OAuth if SF CLI fails
+2. If `SF_CLIENT_ID` and `SF_CLIENT_SECRET` are set: Use OAuth
+3. If neither configured: Error with setup instructions for both methods
+
+### SQL Query Constraints
+
+- All queries use PostgreSQL dialect
+- All identifiers must be quoted and use exact casing
+- Use `list_tables()` and `describe_table()` to discover schema before querying
+- Queries are executed in the specified `dataspace` (default: "default")
+
+### Error Handling
+
+- API errors are parsed from Connect API's nested JSON format
+- Error responses contain: status code, reason, and message (potentially nested JSON)
+- Long-running queries use polling to avoid timeouts
+- Pagination continues until all rows are retrieved or an error occurs
+
+## Logging
+
+The codebase uses Python's standard logging throughout:
+- Module-level loggers: `logger = logging.getLogger(__name__)`
+- Default level: INFO
+- Test scripts can set DEBUG for verbose output
+- Log format: `'%(asctime)s - %(name)s - %(levelname)s - %(message)s'`
+
+## Governance
+
+This is a **published but not supported** project per CONTRIBUTING.md. Occasional work may be done, but active solicitation of contributions is not expected.

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,181 @@
+# Quick Start Guide - Cursor MCP Configuration
+
+## For SF CLI Users (Recommended)
+
+### 1. Authenticate with SF CLI
+```bash
+sf org login web --alias my-datacloud-org
+```
+
+### 2. Get Your Paths
+```bash
+# Get Python path
+which python3
+# Output example: /usr/local/bin/python3
+
+# Get server.py path
+cd /path/to/datacloud-mcp-query
+pwd
+# Output example: /Users/john/projects/datacloud-mcp-query
+# Your server.py is at: /Users/john/projects/datacloud-mcp-query/server.py
+```
+
+### 3. Add to Cursor
+
+**Cursor Settings → MCP → Add new global MCP server**
+
+Copy this configuration and **replace the three placeholder values**:
+
+- `"/usr/local/bin/python3"` — your Python path from `which python3`
+- `"/Users/john/projects/datacloud-mcp-query/server.py"` — your full path to server.py
+- `"my-datacloud-org"` — your SF CLI org alias from `sf org list`
+
+```json
+{
+  "mcpServers": {
+    "datacloud": {
+      "command": "/usr/local/bin/python3",
+      "args": ["/Users/john/projects/datacloud-mcp-query/server.py"],
+      "env": {
+        "SF_ORG_ALIAS": "my-datacloud-org"
+      },
+      "disabled": false,
+      "autoApprove": ["describe_table", "list_tables"]
+    }
+  }
+}
+```
+
+### 4. Verify
+- Click refresh in Cursor MCP settings
+- You should see tools: `query`, `list_tables`, `describe_table`
+
+---
+
+## For OAuth Users
+
+### 1. Create Connected App
+See [CONNECTED_APP_SETUP.md](CONNECTED_APP_SETUP.md) for instructions.
+
+### 2. Get Your Paths
+```bash
+# Get Python path
+which python3
+# Output example: /usr/local/bin/python3
+
+# Get server.py path
+cd /path/to/datacloud-mcp-query
+pwd
+# Output example: /Users/john/projects/datacloud-mcp-query
+```
+
+### 3. Add to Cursor
+
+**Cursor Settings → MCP → Add new global MCP server**
+
+Copy this configuration and **replace the four placeholder values**:
+
+- `"/usr/local/bin/python3"` — your Python path from `which python3`
+- `"/Users/john/projects/datacloud-mcp-query/server.py"` — your full path to server.py
+- `"3MVG9..."` — your Connected App's Client ID
+- `"ABC123..."` — your Connected App's Client Secret
+
+```json
+{
+  "mcpServers": {
+    "datacloud": {
+      "command": "/usr/local/bin/python3",
+      "args": ["/Users/john/projects/datacloud-mcp-query/server.py"],
+      "env": {
+        "SF_CLIENT_ID": "3MVG9...",
+        "SF_CLIENT_SECRET": "ABC123..."
+      },
+      "disabled": false,
+      "autoApprove": ["describe_table", "list_tables"]
+    }
+  }
+}
+```
+
+### 4. Verify
+- Click refresh in Cursor MCP settings
+- You should see tools: `query`, `list_tables`, `describe_table`
+- First query will open a browser for OAuth authentication
+
+---
+
+## Common Issues
+
+### "Command not found" or "File not found"
+❌ **Wrong:**
+```json
+"command": "python3",
+"args": ["server.py"]
+```
+
+✅ **Correct:**
+```json
+"command": "/usr/local/bin/python3",
+"args": ["/Users/john/projects/datacloud-mcp-query/server.py"]
+```
+
+Use **absolute paths** for both command and args!
+
+### "No module named 'mcp'" or similar import errors
+Your Python doesn't have the dependencies installed.
+
+**Solution:**
+```bash
+cd /path/to/datacloud-mcp-query
+pip install -r requirements.txt
+
+# Then use the same Python in your config:
+which python3
+```
+
+### SF CLI: "org not authenticated"
+```bash
+# Check your authenticated orgs
+sf org list
+
+# If your org isn't listed, authenticate:
+sf org login web --alias my-org
+```
+
+### Tools not showing in Cursor
+1. Click the **refresh** button in Cursor MCP settings
+2. Check the MCP logs in Cursor for errors
+3. Test manually: `/usr/local/bin/python3 /path/to/server.py` should start the server
+
+---
+
+## Testing Your Configuration
+
+Before adding to Cursor, test that the server starts:
+
+```bash
+# For SF CLI auth:
+export SF_ORG_ALIAS="my-org"
+/usr/local/bin/python3 /path/to/datacloud-mcp-query/server.py
+
+# For OAuth auth:
+export SF_CLIENT_ID="3MVG9..."
+export SF_CLIENT_SECRET="ABC123..."
+/usr/local/bin/python3 /path/to/datacloud-mcp-query/server.py
+```
+
+You should see:
+```
+2026-02-20 15:00:00 - auth_factory - INFO - Successfully configured SF CLI authentication...
+2026-02-20 15:00:00 - __main__ - INFO - Starting MCP server
+```
+
+If you see errors, fix them before adding to Cursor.
+
+---
+
+## Need Help?
+
+- Full documentation: [README.md](README.md)
+- Connected App setup: [CONNECTED_APP_SETUP.md](CONNECTED_APP_SETUP.md)
+- Architecture details: [CLAUDE.md](CLAUDE.md)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Here's a complete, working configuration example with SF CLI authentication:
 **Problem: "Python not found" or "module not found" errors**
 - Make sure you're using the full absolute path to Python (not just `python3`)
 - If using a virtual environment, use the venv's Python: `/path/to/venv/bin/python`
+- Install the project dependencies against the same Python interpreter you configured in your Agent: `/path/to/python3 -m pip install -r requirements.txt`
 - Test your paths first: `/usr/bin/python3 /path/to/server.py` (should show MCP startup logs)
 
 **Problem: Server fails to start**

--- a/README.md
+++ b/README.md
@@ -2,61 +2,204 @@
 
 This MCP server provides a seamless integration between Cursor and Salesforce Data Cloud (formerly known as CDP), allowing you to execute SQL queries directly from Cursor. The server handles OAuth authentication with Salesforce and provides tools for exploring and querying Data Cloud tables.
 
+📚 **New to this? Start with [QUICK_START.md](QUICK_START.md)** for copy-paste configuration examples.
+
 ## Features
 
 - Execute SQL queries against Salesforce Data Cloud
 - List available tables in the database
 - Describe table columns and structure
-- Automatic OAuth2 authentication flow with Salesforce
+- Flexible authentication: SF CLI or OAuth2 with automatic fallback
 
 ## Adding to Cursor
 
-1. Clone this repository to your local machine
-2. Install the required dependencies:
-   ```bash
-   pip install -r requirements.txt
-   ```
-3. Connect to the MCP server in Cursor:
-   - Open Cursor IDE.
-   - Go to **Cursor Settings** → **MCP**.
-   - Click on **Add new global MCP server**.
-   - Fill in the details:
-   ```json
-       "mcpServers": {
-         ...
-        "datacloud": {
-          "command": "<path to python>",
-          "args": [
-            "<full path to>/server.py"
-          ],
-          "env": {
-            "SF_CLIENT_ID": "<Client Id>",
-            "SF_CLIENT_SECRET": "<Client Secret>>"
-          },
-          "disabled": false,
-          "autoApprove": ["suggest_table_and_fields", "describe_table", "list_tables"]
-        }
-        ...
-      }
-   ```
-   - Enable the MCP server and click refresh which should show the tool list
+### Step 1: Clone and Install Dependencies
+
+```bash
+# Clone the repository
+git clone https://github.com/your-org/datacloud-mcp-query.git
+cd datacloud-mcp-query
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### Step 2: Get Your Paths
+
+You'll need the absolute paths to both Python and server.py for the MCP configuration:
+
+```bash
+# Get your Python path
+which python3
+# Example output: /usr/bin/python3 or /Users/yourname/.pyenv/shims/python3
+
+# Get the full path to server.py (run from the repo directory)
+pwd
+# Example output: /Users/yourname/projects/datacloud-mcp-query
+# Your server.py path will be: /Users/yourname/projects/datacloud-mcp-query/server.py
+```
+
+### Step 3: Set Up Authentication
+
+Choose SF CLI (recommended) or OAuth PKCE - see Configuration section below for details.
+
+### Step 4: Add to Cursor
+
+**Option A: Using Cursor UI (Recommended)**
+1. Open Cursor IDE
+2. Go to **Cursor Settings** → **MCP**
+3. Click **Add new global MCP server**
+4. Use one of the configuration examples below (replace paths with your actual paths from Step 2)
+5. Enable the MCP server and click refresh to see the tool list
+
+**Option B: Edit Config File Directly**
+
+Alternatively, you can edit the MCP config file directly:
+
+**Location:**
+- macOS: `~/Library/Application Support/Cursor/User/globalStorage/mcp-settings.json`
+- Linux: `~/.config/Cursor/User/globalStorage/mcp-settings.json`
+- Windows: `%APPDATA%\Cursor\User\globalStorage\mcp-settings.json`
+
+Add the configuration from the examples below to this file.
 
 ## Configuration
 
-The server requires the following environment variables:
+The server supports two authentication methods. Choose the one that works best for your setup.
 
-### Required Environment Variables
+### Authentication Method 1: SF CLI (Recommended)
 
+If you already use the Salesforce CLI for development, this is the simplest option.
+
+**Prerequisites:**
+- Install Salesforce CLI: https://developer.salesforce.com/tools/salesforcecli
+- Authenticate with your org: `sf org login web --alias myorg`
+
+**Environment Variables:**
+- `SF_ORG_ALIAS`: Your SF CLI org alias or username (e.g., "myorg")
+
+**Cursor MCP Configuration:**
+
+Add this to your Cursor MCP settings (replace the paths with your actual paths from Step 2):
+
+```json
+{
+  "mcpServers": {
+    "datacloud": {
+      "command": "/usr/bin/python3",
+      "args": ["/Users/yourname/projects/datacloud-mcp-query/server.py"],
+      "env": {
+        "SF_ORG_ALIAS": "myorg"
+      },
+      "disabled": false,
+      "autoApprove": ["describe_table", "list_tables"]
+    }
+  }
+}
+```
+
+**What to replace:**
+- `/usr/bin/python3` → Your Python path from `which python3`
+- `/Users/yourname/projects/datacloud-mcp-query/server.py` → Your full path to server.py
+- `myorg` → Your SF CLI org alias (from `sf org list`)
+
+### Authentication Method 2: OAuth PKCE
+
+Use this method if you need a standalone setup without the SF CLI.
+
+**Prerequisites:**
+- Create a Salesforce Connected App with PKCE enabled
+- See [Connected App Setup Guide](CONNECTED_APP_SETUP.md) for detailed instructions
+
+**Environment Variables:**
 - `SF_CLIENT_ID`: Your Salesforce OAuth client ID
 - `SF_CLIENT_SECRET`: Your Salesforce OAuth client secret
+- `SF_LOGIN_URL` (optional): The Salesforce login URL (default: "login.salesforce.com")
+- `SF_CALLBACK_URL` (optional): OAuth callback URL (default: "http://localhost:55556/Callback")
 
-See [Connected App Setup Guide](CONNECTED_APP_SETUP.md) for instructions on how to obtain these credentials.
+**Cursor MCP Configuration:**
 
-### Optional Environment Variables
+Add this to your Cursor MCP settings (replace the paths and credentials with your values):
 
-- `SF_LOGIN_URL`: The Salesforce login URL (default: 'login.salesforce.com')
-- `SF_CALLBACK_URL`: The OAuth callback URL for the authentication flow (default: 'http://localhost:5556/Callback'). This URL must be registered in your Salesforce connected app settings. See [Connected App Setup Guide](CONNECTED_APP_SETUP.md) for detailed instructions.
+```json
+{
+  "mcpServers": {
+    "datacloud": {
+      "command": "/usr/bin/python3",
+      "args": ["/Users/yourname/projects/datacloud-mcp-query/server.py"],
+      "env": {
+        "SF_CLIENT_ID": "3MVG9...",
+        "SF_CLIENT_SECRET": "ABC123..."
+      },
+      "disabled": false,
+      "autoApprove": ["describe_table", "list_tables"]
+    }
+  }
+}
+```
+
+**What to replace:**
+- `/usr/bin/python3` → Your Python path from `which python3`
+- `/Users/yourname/projects/datacloud-mcp-query/server.py` → Your full path to server.py
+- `3MVG9...` → Your Connected App's Client ID
+- `ABC123...` → Your Connected App's Client Secret
+
+**Optional environment variables** (add to `env` if needed):
+```json
+"SF_LOGIN_URL": "login.salesforce.com",
+"SF_CALLBACK_URL": "http://localhost:55556/Callback"
+```
+
+### Auto-Detection Logic
+
+The server automatically detects which authentication method to use:
+
+1. **If `SF_ORG_ALIAS` is set:** Tries SF CLI authentication first
+   - If SF CLI is available and authentication succeeds → Uses SF CLI
+   - If SF CLI fails → Falls back to OAuth (if configured)
+2. **If `SF_CLIENT_ID` and `SF_CLIENT_SECRET` are set:** Uses OAuth PKCE authentication
+3. **If neither is configured:** Shows error with setup instructions
+
+### Other Environment Variables
+
 - `DEFAULT_LIST_TABLE_FILTER`: Filter pattern for listing tables (default: '%'). You can use this to filter for example to known "curated" tables that all share the same prefix. You can use the SQL Like syntax to express the filters.
+
+### Complete Configuration Example
+
+Here's a complete, working configuration example with SF CLI authentication:
+
+```json
+{
+  "mcpServers": {
+    "datacloud": {
+      "command": "/usr/local/bin/python3",
+      "args": ["/Users/john/projects/datacloud-mcp-query/server.py"],
+      "env": {
+        "SF_ORG_ALIAS": "my-datacloud-org"
+      },
+      "disabled": false,
+      "autoApprove": ["describe_table", "list_tables"]
+    }
+  }
+}
+```
+
+### Troubleshooting
+
+**Problem: "Python not found" or "module not found" errors**
+- Make sure you're using the full absolute path to Python (not just `python3`)
+- If using a virtual environment, use the venv's Python: `/path/to/venv/bin/python`
+- Test your paths first: `/usr/bin/python3 /path/to/server.py` (should show MCP startup logs)
+
+**Problem: Server fails to start**
+- Check authentication is configured: Run `export SF_ORG_ALIAS=myorg && python server.py` to see error messages
+- For SF CLI: Verify with `sf org list` that your org is authenticated
+- For OAuth: Verify your Connected App credentials are correct
+
+**Problem: "No tools showing" in Cursor**
+- Click the refresh button in Cursor MCP settings
+- Check Cursor logs for MCP server errors
+- Verify the server can start manually: `python server.py`
 
 ## Available Tools
 
@@ -74,7 +217,16 @@ The server provides the following tools:
 
 ## Authentication
 
-The server implements an OAuth2 flow with Salesforce:
+The server supports two authentication methods:
+
+### SF CLI Authentication
+- Uses your existing SF CLI authentication (`sf org login web`)
+- Retrieves access tokens via `sf org display` command
+- Caches tokens for 5 minutes to reduce overhead
+- No browser authentication required during MCP server operation
+
+### OAuth PKCE Authentication
+- Implements OAuth2 flow with PKCE extension
 - Automatically opens a browser window for authentication
 - Handles token exchange and refresh
 - Maintains session for subsequent queries

--- a/auth_factory.py
+++ b/auth_factory.py
@@ -1,0 +1,133 @@
+"""
+Authentication factory for datacloud-mcp-query.
+
+Provides auto-detection logic to choose the appropriate authentication method.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from auth_interface import AuthProvider
+
+from sf_cli_auth import SFCLIAuth
+from oauth import OAuthConfig, OAuthSession
+
+# Get logger for this module
+logger = logging.getLogger(__name__)
+
+
+class AuthenticationError(Exception):
+    """Exception raised when authentication cannot be configured."""
+    pass
+
+
+def _build_error_message() -> str:
+    """
+    Build a comprehensive error message based on what's configured.
+
+    Returns:
+        str: Detailed error message with setup instructions
+    """
+    sf_org_alias = os.getenv("SF_ORG_ALIAS")
+    sf_client_id = os.getenv("SF_CLIENT_ID")
+    sf_client_secret = os.getenv("SF_CLIENT_SECRET")
+
+    base_message = "No authentication method is configured.\n\n"
+
+    # Determine which specific error scenario we're in
+    if sf_org_alias and not sf_client_id:
+        return base_message + (
+            "SF_ORG_ALIAS is set, but SF CLI authentication failed.\n"
+            "Ensure you've authenticated via:\n"
+            f"  sf org login web --alias {sf_org_alias}\n\n"
+            "Alternatively, configure OAuth authentication with:\n"
+            "  export SF_CLIENT_ID='your_client_id'\n"
+            "  export SF_CLIENT_SECRET='your_client_secret'\n"
+            "See CONNECTED_APP_SETUP.md for OAuth setup instructions.\n"
+        )
+
+    if sf_client_id and not sf_client_secret:
+        return base_message + (
+            "SF_CLIENT_ID is set but SF_CLIENT_SECRET is missing.\n"
+            "For OAuth authentication, both are required:\n"
+            "  export SF_CLIENT_SECRET='your_client_secret'\n"
+        )
+
+    if sf_client_secret and not sf_client_id:
+        return base_message + (
+            "SF_CLIENT_SECRET is set but SF_CLIENT_ID is missing.\n"
+            "For OAuth authentication, both are required:\n"
+            "  export SF_CLIENT_ID='your_client_id'\n"
+        )
+
+    # No configuration at all - provide full setup instructions
+    return base_message + (
+        "Choose one of the following authentication methods:\n\n"
+        "Method 1: SF CLI (Recommended)\n"
+        "  1. Install SF CLI: https://developer.salesforce.com/tools/salesforcecli\n"
+        "  2. Authenticate: sf org login web --alias myorg\n"
+        "  3. Set environment variable: export SF_ORG_ALIAS='myorg'\n\n"
+        "Method 2: OAuth PKCE\n"
+        "  1. Create a Connected App (see CONNECTED_APP_SETUP.md)\n"
+        "  2. Set environment variables:\n"
+        "     export SF_CLIENT_ID='your_client_id'\n"
+        "     export SF_CLIENT_SECRET='your_client_secret'\n"
+    )
+
+
+def create_auth_provider() -> AuthProvider:
+    """
+    Create an authentication provider with auto-detection.
+
+    Auto-detection logic:
+    1. If SF_ORG_ALIAS is set and SF CLI is available:
+       - Try SF CLI authentication
+       - If successful, return SFCLIAuth instance
+       - If failed, log warning and continue to OAuth fallback
+    2. If SF_CLIENT_ID and SF_CLIENT_SECRET are set:
+       - Return OAuthSession instance
+    3. Otherwise:
+       - Raise AuthenticationError with setup instructions
+
+    Returns:
+        AuthProvider: An initialized authentication provider
+
+    Raises:
+        AuthenticationError: If no authentication method can be configured
+    """
+    sf_org_alias = os.getenv("SF_ORG_ALIAS")
+
+    # Try SF CLI authentication first if configured
+    if sf_org_alias and SFCLIAuth.is_available():
+        logger.info(f"SF_ORG_ALIAS is set to '{sf_org_alias}', attempting SF CLI authentication")
+        try:
+            auth_provider = SFCLIAuth(sf_org_alias)
+            # Test authentication by calling get_token()
+            auth_provider.get_token()
+            logger.info(f"Successfully configured SF CLI authentication with org: {sf_org_alias}")
+            return auth_provider
+        except Exception as e:
+            logger.warning(
+                f"SF CLI authentication failed: {str(e)}\n"
+                "Falling back to OAuth if configured"
+            )
+
+    # Try OAuth authentication if configured
+    if OAuthSession.is_available():
+        logger.info("OAuth credentials configured, using OAuth PKCE authentication")
+        try:
+            oauth_session = OAuthSession(OAuthConfig.from_env())
+            logger.info("Successfully configured OAuth PKCE authentication")
+            return oauth_session
+        except SystemExit:
+            # OAuthConfig.from_env() calls sys.exit(1) on missing vars
+            # This shouldn't happen since we checked is_available(), but handle it anyway
+            pass
+
+    # No authentication method available
+    error_message = _build_error_message()
+    logger.error(f"Authentication configuration failed:\n{error_message}")
+    raise AuthenticationError(error_message)

--- a/auth_factory.py
+++ b/auth_factory.py
@@ -40,14 +40,13 @@ def _build_error_message() -> str:
     # Determine which specific error scenario we're in
     if sf_org_alias and not sf_client_id:
         return base_message + (
-            "SF_ORG_ALIAS is set, but SF CLI authentication failed.\n"
-            "Ensure you've authenticated via:\n"
-            f"  sf org login web --alias {sf_org_alias}\n\n"
+            f"SF_ORG_ALIAS is set to '{sf_org_alias}', but the sf CLI binary "
+            "was not found in PATH.\n"
+            "Install SF CLI: https://developer.salesforce.com/tools/salesforcecli\n\n"
             "Alternatively, configure OAuth authentication with:\n"
             "  export SF_CLIENT_ID='your_client_id'\n"
             "  export SF_CLIENT_SECRET='your_client_secret'\n"
-            "See CONNECTED_APP_SETUP.md for OAuth setup instructions.\n"
-        )
+            "See CONNECTED_APP_SETUP.md for OAuth setup instructions.\n")
 
     if sf_client_id and not sf_client_secret:
         return base_message + (
@@ -79,43 +78,42 @@ def _build_error_message() -> str:
 
 def create_auth_provider() -> AuthProvider:
     """
-    Create an authentication provider with auto-detection.
+    Create an authentication provider based on configured environment variables.
 
-    Auto-detection logic:
-    1. If SF_ORG_ALIAS is set and SF CLI is available:
-       - Try SF CLI authentication
-       - If successful, return SFCLIAuth instance
-       - If failed, log warning and continue to OAuth fallback
-    2. If SF_CLIENT_ID and SF_CLIENT_SECRET are set:
-       - Return OAuthSession instance
-    3. Otherwise:
-       - Raise AuthenticationError with setup instructions
+    Credentials are not fetched eagerly -- the returned provider will authenticate
+    lazily on first use, keeping MCP server startup fast.
+
+    Auto-detection priority:
+    1. SF CLI (if SF_ORG_ALIAS is set and sf binary exists)
+    2. OAuth PKCE (if SF_CLIENT_ID and SF_CLIENT_SECRET are set)
+    3. Raises AuthenticationError with setup instructions
+
+    If both methods are configured, SF CLI is used and a warning is logged.
 
     Returns:
-        AuthProvider: An initialized authentication provider
+        AuthProvider: A configured (but not yet authenticated) provider
 
     Raises:
         AuthenticationError: If no authentication method can be configured
     """
-    sf_org_alias = os.getenv("SF_ORG_ALIAS")
+    sf_cli_configured = SFCLIAuth.is_configured()
+    oauth_configured = OAuthSession.is_configured()
+
+    if sf_cli_configured and oauth_configured:
+        logger.warning(
+            "Both SF CLI (SF_ORG_ALIAS) and OAuth (SF_CLIENT_ID/SF_CLIENT_SECRET) "
+            "are configured. Using SF CLI. To use OAuth instead, unset SF_ORG_ALIAS.")
 
     # Try SF CLI authentication first if configured
-    if sf_org_alias and SFCLIAuth.is_available():
+    if sf_cli_configured:
+        sf_org_alias = os.getenv("SF_ORG_ALIAS")
         logger.info(
-            f"SF_ORG_ALIAS is set to '{sf_org_alias}', attempting SF CLI authentication")
-        try:
-            auth_provider = SFCLIAuth(sf_org_alias)
-            logger.info(
-                f"Successfully configured SF CLI authentication with org: {sf_org_alias}")
-            return auth_provider
-        except Exception as e:
-            logger.warning(
-                f"SF CLI authentication failed: {str(e)}\n"
-                "Falling back to OAuth if configured"
-            )
+            f"Using SF CLI authentication with org: {sf_org_alias} "
+            "(credentials will be fetched on first use)")
+        return SFCLIAuth(sf_org_alias)
 
     # Try OAuth authentication if configured
-    if OAuthSession.is_available():
+    if oauth_configured:
         logger.info(
             "OAuth credentials configured, using OAuth PKCE authentication")
         try:

--- a/auth_factory.py
+++ b/auth_factory.py
@@ -74,8 +74,7 @@ def _build_error_message() -> str:
         "  1. Create a Connected App (see CONNECTED_APP_SETUP.md)\n"
         "  2. Set environment variables:\n"
         "     export SF_CLIENT_ID='your_client_id'\n"
-        "     export SF_CLIENT_SECRET='your_client_secret'\n"
-    )
+        "     export SF_CLIENT_SECRET='your_client_secret'\n")
 
 
 def create_auth_provider() -> AuthProvider:
@@ -102,12 +101,12 @@ def create_auth_provider() -> AuthProvider:
 
     # Try SF CLI authentication first if configured
     if sf_org_alias and SFCLIAuth.is_available():
-        logger.info(f"SF_ORG_ALIAS is set to '{sf_org_alias}', attempting SF CLI authentication")
+        logger.info(
+            f"SF_ORG_ALIAS is set to '{sf_org_alias}', attempting SF CLI authentication")
         try:
             auth_provider = SFCLIAuth(sf_org_alias)
-            # Test authentication by calling get_token()
-            auth_provider.get_token()
-            logger.info(f"Successfully configured SF CLI authentication with org: {sf_org_alias}")
+            logger.info(
+                f"Successfully configured SF CLI authentication with org: {sf_org_alias}")
             return auth_provider
         except Exception as e:
             logger.warning(
@@ -117,14 +116,14 @@ def create_auth_provider() -> AuthProvider:
 
     # Try OAuth authentication if configured
     if OAuthSession.is_available():
-        logger.info("OAuth credentials configured, using OAuth PKCE authentication")
+        logger.info(
+            "OAuth credentials configured, using OAuth PKCE authentication")
         try:
             oauth_session = OAuthSession(OAuthConfig.from_env())
             logger.info("Successfully configured OAuth PKCE authentication")
             return oauth_session
         except OAuthConfigError as e:
             logger.warning(f"OAuth configuration failed: {e}")
-
 
     # No authentication method available
     error_message = _build_error_message()

--- a/auth_factory.py
+++ b/auth_factory.py
@@ -12,8 +12,14 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from auth_interface import AuthProvider
 
-from sf_cli_auth import SFCLIAuth
-from oauth import OAuthConfig, OAuthConfigError, OAuthSession
+from sf_cli_auth import SFCLIAuth, ENV_SF_ORG_ALIAS
+from oauth import (
+    OAuthConfig,
+    OAuthConfigError,
+    OAuthSession,
+    ENV_SF_CLIENT_ID,
+    ENV_SF_CLIENT_SECRET,
+)
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -31,35 +37,35 @@ def _build_error_message() -> str:
     Returns:
         str: Detailed error message with setup instructions
     """
-    sf_org_alias = os.getenv("SF_ORG_ALIAS")
-    sf_client_id = os.getenv("SF_CLIENT_ID")
-    sf_client_secret = os.getenv("SF_CLIENT_SECRET")
+    sf_org_alias = os.getenv(ENV_SF_ORG_ALIAS)
+    sf_client_id = os.getenv(ENV_SF_CLIENT_ID)
+    sf_client_secret = os.getenv(ENV_SF_CLIENT_SECRET)
 
     base_message = "No authentication method is configured.\n\n"
 
     # Determine which specific error scenario we're in
     if sf_org_alias and not sf_client_id:
         return base_message + (
-            f"SF_ORG_ALIAS is set to '{sf_org_alias}', but the sf CLI binary "
+            f"{ENV_SF_ORG_ALIAS} is set to '{sf_org_alias}', but the sf CLI binary "
             "was not found in PATH.\n"
             "Install SF CLI: https://developer.salesforce.com/tools/salesforcecli\n\n"
             "Alternatively, configure OAuth authentication with:\n"
-            "  export SF_CLIENT_ID='your_client_id'\n"
-            "  export SF_CLIENT_SECRET='your_client_secret'\n"
+            f"  export {ENV_SF_CLIENT_ID}='your_client_id'\n"
+            f"  export {ENV_SF_CLIENT_SECRET}='your_client_secret'\n"
             "See CONNECTED_APP_SETUP.md for OAuth setup instructions.\n")
 
     if sf_client_id and not sf_client_secret:
         return base_message + (
-            "SF_CLIENT_ID is set but SF_CLIENT_SECRET is missing.\n"
+            f"{ENV_SF_CLIENT_ID} is set but {ENV_SF_CLIENT_SECRET} is missing.\n"
             "For OAuth authentication, both are required:\n"
-            "  export SF_CLIENT_SECRET='your_client_secret'\n"
+            f"  export {ENV_SF_CLIENT_SECRET}='your_client_secret'\n"
         )
 
     if sf_client_secret and not sf_client_id:
         return base_message + (
-            "SF_CLIENT_SECRET is set but SF_CLIENT_ID is missing.\n"
+            f"{ENV_SF_CLIENT_SECRET} is set but {ENV_SF_CLIENT_ID} is missing.\n"
             "For OAuth authentication, both are required:\n"
-            "  export SF_CLIENT_ID='your_client_id'\n"
+            f"  export {ENV_SF_CLIENT_ID}='your_client_id'\n"
         )
 
     # No configuration at all - provide full setup instructions
@@ -68,12 +74,12 @@ def _build_error_message() -> str:
         "Method 1: SF CLI (Recommended)\n"
         "  1. Install SF CLI: https://developer.salesforce.com/tools/salesforcecli\n"
         "  2. Authenticate: sf org login web --alias myorg\n"
-        "  3. Set environment variable: export SF_ORG_ALIAS='myorg'\n\n"
+        f"  3. Set environment variable: export {ENV_SF_ORG_ALIAS}='myorg'\n\n"
         "Method 2: OAuth PKCE\n"
         "  1. Create a Connected App (see CONNECTED_APP_SETUP.md)\n"
         "  2. Set environment variables:\n"
-        "     export SF_CLIENT_ID='your_client_id'\n"
-        "     export SF_CLIENT_SECRET='your_client_secret'\n")
+        f"     export {ENV_SF_CLIENT_ID}='your_client_id'\n"
+        f"     export {ENV_SF_CLIENT_SECRET}='your_client_secret'\n")
 
 
 def create_auth_provider() -> AuthProvider:
@@ -101,12 +107,13 @@ def create_auth_provider() -> AuthProvider:
 
     if sf_cli_configured and oauth_configured:
         logger.warning(
-            "Both SF CLI (SF_ORG_ALIAS) and OAuth (SF_CLIENT_ID/SF_CLIENT_SECRET) "
-            "are configured. Using SF CLI. To use OAuth instead, unset SF_ORG_ALIAS.")
+            f"Both SF CLI ({ENV_SF_ORG_ALIAS}) and OAuth "
+            f"({ENV_SF_CLIENT_ID}/{ENV_SF_CLIENT_SECRET}) are configured. "
+            f"Using SF CLI. To use OAuth instead, unset {ENV_SF_ORG_ALIAS}.")
 
     # Try SF CLI authentication first if configured
     if sf_cli_configured:
-        sf_org_alias = os.getenv("SF_ORG_ALIAS")
+        sf_org_alias = os.getenv(ENV_SF_ORG_ALIAS)
         logger.info(
             f"Using SF CLI authentication with org: {sf_org_alias} "
             "(credentials will be fetched on first use)")

--- a/auth_factory.py
+++ b/auth_factory.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from auth_interface import AuthProvider
 
 from sf_cli_auth import SFCLIAuth
-from oauth import OAuthConfig, OAuthSession
+from oauth import OAuthConfig, OAuthConfigError, OAuthSession
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -122,10 +122,9 @@ def create_auth_provider() -> AuthProvider:
             oauth_session = OAuthSession(OAuthConfig.from_env())
             logger.info("Successfully configured OAuth PKCE authentication")
             return oauth_session
-        except SystemExit:
-            # OAuthConfig.from_env() calls sys.exit(1) on missing vars
-            # This shouldn't happen since we checked is_available(), but handle it anyway
-            pass
+        except OAuthConfigError as e:
+            logger.warning(f"OAuth configuration failed: {e}")
+
 
     # No authentication method available
     error_message = _build_error_message()

--- a/auth_interface.py
+++ b/auth_interface.py
@@ -39,11 +39,11 @@ class AuthProvider(Protocol):
         ...
 
     @staticmethod
-    def is_available() -> bool:
+    def is_configured() -> bool:
         """
-        Check if this authentication method is configured and available.
+        Check if the required environment variables for this authentication method are set.
 
         Returns:
-            bool: True if the authentication method can be used, False otherwise
+            bool: True if the required configuration is present, False otherwise
         """
         ...

--- a/auth_interface.py
+++ b/auth_interface.py
@@ -1,0 +1,49 @@
+"""
+Authentication protocol interface for datacloud-mcp-query.
+
+Defines the common interface that all authentication providers must implement.
+Uses Protocol for structural subtyping (duck typing).
+"""
+from typing import Protocol
+
+
+class AuthProvider(Protocol):
+    """
+    Protocol defining the interface for authentication providers.
+
+    All authentication implementations (OAuth, SF CLI, etc.) must provide these methods.
+    """
+
+    def get_token(self) -> str:
+        """
+        Get a valid access token for Salesforce API calls.
+
+        Returns:
+            str: A valid Salesforce access token
+
+        Raises:
+            Exception: If authentication fails or token cannot be obtained
+        """
+        ...
+
+    def get_instance_url(self) -> str:
+        """
+        Get the Salesforce instance URL for API calls.
+
+        Returns:
+            str: The Salesforce instance URL (e.g., "https://example.my.salesforce.com")
+
+        Raises:
+            Exception: If instance URL cannot be determined
+        """
+        ...
+
+    @staticmethod
+    def is_available() -> bool:
+        """
+        Check if this authentication method is configured and available.
+
+        Returns:
+            bool: True if the authentication method can be used, False otherwise
+        """
+        ...

--- a/connect_api_dc_sql.py
+++ b/connect_api_dc_sql.py
@@ -172,35 +172,20 @@ def run_query(
 
 
 if __name__ == "__main__":
-    # Configure logging
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
-
-    # Set debug level for this module during testing
-    logger.setLevel(logging.DEBUG)
-
-    # Use the new auth factory (supports both SF CLI and OAuth with auto-detection)
-    # This will automatically choose:
-    #   - SF CLI authentication if SF_ORG_ALIAS is set
-    #   - OAuth PKCE authentication if SF_CLIENT_ID and SF_CLIENT_SECRET are set
+    # Manual smoke test: authenticates and runs a query that spans multiple
+    # pagination batches. Expects SF_ORG_ALIAS or SF_CLIENT_ID/SF_CLIENT_SECRET
+    # to be set in the environment.
     from auth_factory import create_auth_provider
 
-    logger.info("Creating authentication provider with auto-detection...")
-    auth_provider = create_auth_provider()
-
-    # Run a test query that generates 40,000 rows to test pagination
-    logger.info("Running test query with pagination...")
-    result = run_query(
-        auth_provider,
-        "SELECT g::text || rpad(1::text,100) as a, g as b FROM generate_series(1, 40000) g ORDER BY b DESC"
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
     )
 
-    print(f"\n✓ Query completed successfully!")
-    print(f"✓ Query result: {len(result['data'])} rows returned")
-    print(f"✓ Metadata columns: {len(result['metadata'])} columns")
-    print(f"\nFirst 3 rows:")
-    for i, row in enumerate(result['data'][:3]):
-        print(f"  Row {i+1}: {row}")
+    auth_provider = create_auth_provider()
+    result = run_query(
+        auth_provider,
+        "SELECT g::text || rpad(1::text,100) as a, g as b FROM generate_series(1, 40000) g ORDER BY b DESC",
+    )
+    print(f"Rows: {len(result['data'])}, Columns: {len(result['metadata'])}")

--- a/connect_api_dc_sql.py
+++ b/connect_api_dc_sql.py
@@ -1,17 +1,11 @@
 import json
 import logging
 import time
-from typing import Dict, List, Optional, Union, Protocol
+from typing import Dict, List, Optional, Union
 
 import requests
 
-from oauth import OAuthSession, OAuthConfig
-
-
-class AuthProvider(Protocol):
-    """Protocol for authentication providers (SF CLI, OAuth, etc.)"""
-    def get_token(self) -> str: ...
-    def get_instance_url(self) -> str: ...
+from auth_interface import AuthProvider
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -48,6 +42,7 @@ def _handle_error_response(response: requests.Response):
 def run_query(
     auth_provider: AuthProvider,
     sql: str,
+    sql_parameters: Optional[List[Dict[str, Union[str, int, float, bool]]]] = None,
     dataspace: str = "default",
     workload_name: str | None = "data-360-mcp-query-oss",
     pagination_batch_size: int = 100000,
@@ -58,7 +53,12 @@ def run_query(
 
     Args:
         auth_provider: Authentication provider (SF CLI, OAuth, etc.)
-        sql: SQL query string
+        sql: SQL query string (use :paramName placeholders for parameterized queries)
+        sql_parameters: Optional list of parameter dicts, each with "name" and "value" keys,
+            and an optional "type" key. Values can be str, int, float, or bool. Examples:
+            [{"name": "startDate", "value": "2025-01-01T00:00:00Z"}]
+            [{"name": "limit", "value": 100}]
+            [{"name": "active", "value": True}]
         dataspace: Data Cloud dataspace name (default: "default")
         workload_name: Workload name for resource management
         pagination_batch_size: Number of rows to fetch per page
@@ -77,7 +77,9 @@ def run_query(
         common_params["workloadName"] = workload_name
 
     # Step 1: submit the query
-    submit_body = {"sql": sql}
+    submit_body: dict = {"sql": sql}
+    if sql_parameters:
+        submit_body["sqlParameters"] = sql_parameters
     logger.info(
         f"Submitting SQL query to {url_base}, with params: {common_params}")
 

--- a/connect_api_dc_sql.py
+++ b/connect_api_dc_sql.py
@@ -1,11 +1,17 @@
 import json
 import logging
 import time
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, Protocol
 
 import requests
 
 from oauth import OAuthSession, OAuthConfig
+
+
+class AuthProvider(Protocol):
+    """Protocol for authentication providers (SF CLI, OAuth, etc.)"""
+    def get_token(self) -> str: ...
+    def get_instance_url(self) -> str: ...
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
@@ -40,7 +46,7 @@ def _handle_error_response(response: requests.Response):
 
 
 def run_query(
-    oauth_session: OAuthSession,
+    auth_provider: AuthProvider,
     sql: str,
     dataspace: str = "default",
     workload_name: str | None = "data-360-mcp-query-oss",
@@ -50,12 +56,19 @@ def run_query(
     Execute a SQL query using the Data Cloud Query Connect API, handling long-running queries
     and paginated result retrieval.
 
+    Args:
+        auth_provider: Authentication provider (SF CLI, OAuth, etc.)
+        sql: SQL query string
+        dataspace: Data Cloud dataspace name (default: "default")
+        workload_name: Workload name for resource management
+        pagination_batch_size: Number of rows to fetch per page
+
     Returns a dictionary containing:
     - 'data': the complete list of rows (aggregated across all pages) or "(empty)" if no rows
     - 'metadata': the schema/metadata of the result columns
     """
-    base_url = oauth_session.get_instance_url()
-    token = oauth_session.get_token()
+    base_url = auth_provider.get_instance_url()
+    token = auth_provider.get_token()
 
     headers = {"Authorization": f"Bearer {token}"}
     url_base = base_url + "/services/data/v63.0/ssot/query-sql"
@@ -161,10 +174,25 @@ if __name__ == "__main__":
     # Set debug level for this module during testing
     logger.setLevel(logging.DEBUG)
 
-    sf_org: OAuthConfig = OAuthConfig.from_env()
-    oauth_session: OAuthSession = OAuthSession(sf_org)
+    # Use the new auth factory (supports both SF CLI and OAuth with auto-detection)
+    # This will automatically choose:
+    #   - SF CLI authentication if SF_ORG_ALIAS is set
+    #   - OAuth PKCE authentication if SF_CLIENT_ID and SF_CLIENT_SECRET are set
+    from auth_factory import create_auth_provider
 
-    result = run_query(OAuthSession(OAuthConfig.from_env(
-    )), "SELECT g::text || rpad(1::text,100) as a, g as b FROM generate_series(1, 40000) g ORDER BY b DESC")
-    print(f"Query result: {len(result['data'])} rows returned")
-    print(result)
+    logger.info("Creating authentication provider with auto-detection...")
+    auth_provider = create_auth_provider()
+
+    # Run a test query that generates 40,000 rows to test pagination
+    logger.info("Running test query with pagination...")
+    result = run_query(
+        auth_provider,
+        "SELECT g::text || rpad(1::text,100) as a, g as b FROM generate_series(1, 40000) g ORDER BY b DESC"
+    )
+
+    print(f"\n✓ Query completed successfully!")
+    print(f"✓ Query result: {len(result['data'])} rows returned")
+    print(f"✓ Metadata columns: {len(result['metadata'])} columns")
+    print(f"\nFirst 3 rows:")
+    for i, row in enumerate(result['data'][:3]):
+        print(f"  Row {i+1}: {row}")

--- a/connect_api_dc_sql.py
+++ b/connect_api_dc_sql.py
@@ -17,7 +17,8 @@ def _handle_error_response(response: requests.Response):
         message = response.text
         try:
             payload = json.loads(response.text)
-            # Connect API error format: list with first element containing JSON string in "message"
+            # Connect API error format: list with first element containing JSON
+            # string in "message"
             if isinstance(payload, list) and len(payload) > 0:
                 structured_message = payload[0]
                 try:
@@ -84,7 +85,11 @@ def run_query(
         f"Submitting SQL query to {url_base}, with params: {common_params}")
 
     submit_response = requests.post(
-        url_base, json=submit_body, params=common_params, headers=headers, timeout=120)
+        url_base,
+        json=submit_body,
+        params=common_params,
+        headers=headers,
+        timeout=120)
 
     logger.info(
         f"Query submission response: status={submit_response.status_code}, elapsed={submit_response.elapsed.total_seconds():.2f}s")
@@ -112,7 +117,8 @@ def run_query(
             f"Polling query status (attempt {poll_count}): {poll_url}")
 
         poll_params = dict(common_params)
-        # Signal that we want to do long-polling to get best latency for query end notification and minimize RPC calls
+        # Signal that we want to do long-polling to get best latency for query
+        # end notification and minimize RPC calls
         poll_params.update({
             "waitTimeMs": 10000,
         })

--- a/oauth.py
+++ b/oauth.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 import logging
 import os
-import sys
 import base64
 import hashlib
 import secrets
@@ -19,6 +18,11 @@ from rfc3986 import builder as uri_builder
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
+
+
+class OAuthConfigError(Exception):
+    """Raised when OAuth configuration is incomplete or invalid."""
+    pass
 
 
 class OAuthConfig:
@@ -41,9 +45,9 @@ class OAuthConfig:
             "SF_CLIENT_SECRET": client_secret,
         }.items() if not val]
         if missing:
-            print(
-                f"Error: Missing required environment variables: {', '.join(missing)}")
-            sys.exit(1)
+            raise OAuthConfigError(
+                f"Missing required environment variables: {', '.join(missing)}"
+            )
 
         return cls(client_id=client_id, client_secret=client_secret, login_root=login_root, redirect_uri=redirect_uri)
 

--- a/oauth.py
+++ b/oauth.py
@@ -104,9 +104,9 @@ class OAuthSession:
         self.instance_url: str | None = None
 
     @staticmethod
-    def is_available() -> bool:
+    def is_configured() -> bool:
         """
-        Check if OAuth authentication is configured and available.
+        Check if OAuth authentication is configured.
 
         Returns:
             bool: True if SF_CLIENT_ID and SF_CLIENT_SECRET are set

--- a/oauth.py
+++ b/oauth.py
@@ -26,7 +26,12 @@ class OAuthConfigError(Exception):
 
 
 class OAuthConfig:
-    def __init__(self, client_id: str, client_secret: str, login_root: str, redirect_uri: str):
+    def __init__(
+            self,
+            client_id: str,
+            client_secret: str,
+            login_root: str,
+            redirect_uri: str):
         self.client_id = client_id
         self.client_secret = client_secret
         self.login_root = login_root
@@ -49,7 +54,11 @@ class OAuthConfig:
                 f"Missing required environment variables: {', '.join(missing)}"
             )
 
-        return cls(client_id=client_id, client_secret=client_secret, login_root=login_root, redirect_uri=redirect_uri)
+        return cls(
+            client_id=client_id,
+            client_secret=client_secret,
+            login_root=login_root,
+            redirect_uri=redirect_uri)
 
 
 class _RequestHandler(http.server.BaseHTTPRequestHandler):  # pragma: no cover
@@ -172,7 +181,8 @@ class OAuthSession:
             headers={"Accept": "application/json"},
         )
 
-        logger.info(f"Token exchange response: status={response.status_code}, elapsed={response.elapsed.total_seconds():.2f}s")
+        logger.info(
+            f"Token exchange response: status={response.status_code}, elapsed={response.elapsed.total_seconds():.2f}s")
 
         if response.status_code >= 400:
             logger.error(f"Token exchange failed: {response.text}")

--- a/oauth.py
+++ b/oauth.py
@@ -19,6 +19,16 @@ from rfc3986 import builder as uri_builder
 # Get logger for this module
 logger = logging.getLogger(__name__)
 
+# Environment variable names
+ENV_SF_CLIENT_ID = "SF_CLIENT_ID"
+ENV_SF_CLIENT_SECRET = "SF_CLIENT_SECRET"
+ENV_SF_LOGIN_URL = "SF_LOGIN_URL"
+ENV_SF_CALLBACK_URL = "SF_CALLBACK_URL"
+
+# Default values
+DEFAULT_LOGIN_URL = "login.salesforce.com"
+DEFAULT_CALLBACK_URL = "http://localhost:55556/Callback"
+
 
 class OAuthConfigError(Exception):
     """Raised when OAuth configuration is incomplete or invalid."""
@@ -39,15 +49,14 @@ class OAuthConfig:
 
     @classmethod
     def from_env(cls) -> "OAuthConfig":
-        client_id = os.getenv("SF_CLIENT_ID")
-        client_secret = os.getenv("SF_CLIENT_SECRET")
-        login_root = os.getenv("SF_LOGIN_URL", "login.salesforce.com")
-        redirect_uri = os.getenv(
-            "SF_CALLBACK_URL", "http://localhost:55556/Callback")
+        client_id = os.getenv(ENV_SF_CLIENT_ID)
+        client_secret = os.getenv(ENV_SF_CLIENT_SECRET)
+        login_root = os.getenv(ENV_SF_LOGIN_URL, DEFAULT_LOGIN_URL)
+        redirect_uri = os.getenv(ENV_SF_CALLBACK_URL, DEFAULT_CALLBACK_URL)
 
         missing = [name for name, val in {
-            "SF_CLIENT_ID": client_id,
-            "SF_CLIENT_SECRET": client_secret,
+            ENV_SF_CLIENT_ID: client_id,
+            ENV_SF_CLIENT_SECRET: client_secret,
         }.items() if not val]
         if missing:
             raise OAuthConfigError(
@@ -111,8 +120,8 @@ class OAuthSession:
         Returns:
             bool: True if SF_CLIENT_ID and SF_CLIENT_SECRET are set
         """
-        client_id = os.getenv("SF_CLIENT_ID")
-        client_secret = os.getenv("SF_CLIENT_SECRET")
+        client_id = os.getenv(ENV_SF_CLIENT_ID)
+        client_secret = os.getenv(ENV_SF_CLIENT_SECRET)
         return bool(client_id and client_secret)
 
     def _run_oauth_flow(self, scopes: list[str]):

--- a/oauth.py
+++ b/oauth.py
@@ -90,6 +90,18 @@ class OAuthSession:
         self.exp: datetime | None = None
         self.instance_url: str | None = None
 
+    @staticmethod
+    def is_available() -> bool:
+        """
+        Check if OAuth authentication is configured and available.
+
+        Returns:
+            bool: True if SF_CLIENT_ID and SF_CLIENT_SECRET are set
+        """
+        client_id = os.getenv("SF_CLIENT_ID")
+        client_secret = os.getenv("SF_CLIENT_SECRET")
+        return bool(client_id and client_secret)
+
     def _run_oauth_flow(self, scopes: list[str]):
         logger.info(f"Starting OAuth flow with scopes: {scopes}")
         login_url = f"https://{self.config.login_root}/services/oauth2/authorize"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,11 @@
+# Python dependencies for datacloud-mcp-query
+# Install with: pip install -r requirements.txt
+
+# Optional External Dependency (not in PyPI):
+# - Salesforce CLI for SF CLI authentication
+#   Install separately: https://developer.salesforce.com/tools/salesforcecli
+#   Not required if using OAuth PKCE authentication
+
 pydantic>=2.11.7
 requests>=2.32.4
 rfc3986>=2.0.0

--- a/server.py
+++ b/server.py
@@ -4,7 +4,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 import requests
 import os
-from oauth import OAuthConfig, OAuthSession
+from auth_factory import create_auth_provider, AuthenticationError
 from connect_api_dc_sql import run_query
 
 # Get logger for this module
@@ -14,9 +14,12 @@ logger = logging.getLogger(__name__)
 # Create an MCP server
 mcp = FastMCP("Demo")
 
-# Global config and session
-sf_org: OAuthConfig = OAuthConfig.from_env()
-oauth_session: OAuthSession = OAuthSession(sf_org)
+# Global authentication provider
+try:
+    auth_provider = create_auth_provider()
+except AuthenticationError as e:
+    logger.error(f"Authentication configuration error: {e}")
+    raise SystemExit(1) from e
 
 # Non-auth configuration
 DEFAULT_LIST_TABLE_FILTER = os.getenv('DEFAULT_LIST_TABLE_FILTER', '%')
@@ -28,13 +31,13 @@ def query(
         description="A SQL query in the PostgreSQL dialect make sure to always quote all identifies and use the exact casing. To formulate the query first verify which tables and fields to use through the suggest fields tool (or if it is broken through the list tables / describe tables call). Before executing the tool provide the user a succinct summary (targeted to low code users) on the semantics of the query"),
 ):
     # Returns both data and metadata
-    return run_query(oauth_session, sql)
+    return run_query(auth_provider, sql)
 
 
 @mcp.tool(description="Lists the available tables in the database")
 def list_tables() -> list[str]:
     sql = "SELECT c.relname AS TABLE_NAME FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c LEFT JOIN pg_catalog.pg_description d ON (c.oid = d.objoid AND d.objsubid = 0  and d.classoid = 'pg_class'::regclass) WHERE c.relnamespace = n.oid AND c.relname LIKE '%s'" % DEFAULT_LIST_TABLE_FILTER
-    result = run_query(oauth_session, sql)
+    result = run_query(auth_provider, sql)
     # Extract data from the result dictionary
     data = result.get("data", [])
     return [x[0] for x in data]
@@ -45,7 +48,7 @@ def describe_table(
     table: str = Field(description="The table name"),
 ) -> list[str]:
     sql = f"SELECT a.attname FROM pg_catalog.pg_namespace n JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid) JOIN pg_catalog.pg_attribute a ON (a.attrelid = c.oid) JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid) LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid = def.adrelid AND a.attnum = def.adnum) LEFT JOIN pg_catalog.pg_description dsc ON (c.oid = dsc.objoid AND a.attnum = dsc.objsubid) LEFT JOIN pg_catalog.pg_class dc ON (dc.oid = dsc.classoid AND dc.relname = 'pg_class') LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace = dn.oid AND dn.nspname = 'pg_catalog') WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relname='{table}'"
-    result = run_query(oauth_session, sql)
+    result = run_query(auth_provider, sql)
     # Extract data from the result dictionary
     data = result.get("data", [])
     return [x[0] for x in data]

--- a/server.py
+++ b/server.py
@@ -1,9 +1,9 @@
-import json
 import logging
+import os
+
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
-import requests
-import os
+
 from auth_factory import create_auth_provider, AuthenticationError
 from connect_api_dc_sql import run_query
 
@@ -36,8 +36,11 @@ def query(
 
 @mcp.tool(description="Lists the available tables in the database")
 def list_tables() -> list[str]:
-    sql = "SELECT c.relname AS TABLE_NAME FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c LEFT JOIN pg_catalog.pg_description d ON (c.oid = d.objoid AND d.objsubid = 0  and d.classoid = 'pg_class'::regclass) WHERE c.relnamespace = n.oid AND c.relname LIKE '%s'" % DEFAULT_LIST_TABLE_FILTER
-    result = run_query(auth_provider, sql)
+    sql = "SELECT c.relname AS TABLE_NAME FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c LEFT JOIN pg_catalog.pg_description d ON (c.oid = d.objoid AND d.objsubid = 0 AND d.classoid = 'pg_class'::regclass) WHERE c.relnamespace = n.oid AND c.relname LIKE :tableFilter"
+    result = run_query(
+        auth_provider, sql,
+        sql_parameters=[{"name": "tableFilter", "value": DEFAULT_LIST_TABLE_FILTER}],
+    )
     # Extract data from the result dictionary
     data = result.get("data", [])
     return [x[0] for x in data]

--- a/server.py
+++ b/server.py
@@ -47,8 +47,11 @@ def list_tables() -> list[str]:
 def describe_table(
     table: str = Field(description="The table name"),
 ) -> list[str]:
-    sql = f"SELECT a.attname FROM pg_catalog.pg_namespace n JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid) JOIN pg_catalog.pg_attribute a ON (a.attrelid = c.oid) JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid) LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid = def.adrelid AND a.attnum = def.adnum) LEFT JOIN pg_catalog.pg_description dsc ON (c.oid = dsc.objoid AND a.attnum = dsc.objsubid) LEFT JOIN pg_catalog.pg_class dc ON (dc.oid = dsc.classoid AND dc.relname = 'pg_class') LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace = dn.oid AND dn.nspname = 'pg_catalog') WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relname='{table}'"
-    result = run_query(auth_provider, sql)
+    sql = "SELECT a.attname FROM pg_catalog.pg_namespace n JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid) JOIN pg_catalog.pg_attribute a ON (a.attrelid = c.oid) JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid) LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid = def.adrelid AND a.attnum = def.adnum) LEFT JOIN pg_catalog.pg_description dsc ON (c.oid = dsc.objoid AND a.attnum = dsc.objsubid) LEFT JOIN pg_catalog.pg_class dc ON (dc.oid = dsc.classoid AND dc.relname = 'pg_class') LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace = dn.oid AND dn.nspname = 'pg_catalog') WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relname = :tableName"
+    result = run_query(
+        auth_provider, sql,
+        sql_parameters=[{"name": "tableName", "value": table}],
+    )
     # Extract data from the result dictionary
     data = result.get("data", [])
     return [x[0] for x in data]

--- a/sf_cli_auth.py
+++ b/sf_cli_auth.py
@@ -42,14 +42,14 @@ class SFCLIAuth:
         self._instance_url: Optional[str] = None
         self._token_expiry: Optional[datetime] = None
 
-        logger.info(f"Initializing SF CLI authentication with org: {org_alias}")
+        logger.info(
+            f"Initializing SF CLI authentication with org: {org_alias}")
 
         # Validate SF CLI is available
         if not shutil.which("sf"):
             raise Exception(
                 "SF CLI (sf command) not found in PATH. "
-                "Install from: https://developer.salesforce.com/tools/salesforcecli"
-            )
+                "Install from: https://developer.salesforce.com/tools/salesforcecli")
 
         # Test authentication by fetching initial token
         try:
@@ -58,8 +58,7 @@ class SFCLIAuth:
             raise Exception(
                 f"Failed to authenticate with SF CLI org '{org_alias}'. "
                 f"Ensure you've authenticated via: sf org login web --alias {org_alias}\n"
-                f"Error: {str(e)}"
-            ) from e
+                f"Error: {str(e)}") from e
 
     @staticmethod
     def is_available() -> bool:
@@ -69,8 +68,8 @@ class SFCLIAuth:
         Returns:
             bool: True if SF_ORG_ALIAS is set and sf command exists
         """
-        return bool(os.getenv("SF_ORG_ALIAS")) and shutil.which("sf") is not None
-
+        has_alias = bool(os.getenv("SF_ORG_ALIAS"))
+        return has_alias and shutil.which("sf") is not None
 
     def _refresh_credentials(self) -> None:
         """
@@ -97,7 +96,8 @@ class SFCLIAuth:
             output = json.loads(result.stdout)
 
             # Extract access token and instance URL
-            # SF CLI output format: {"result": {"accessToken": "...", "instanceUrl": "..."}}
+            # SF CLI output format: {"result": {"accessToken": "...",
+            # "instanceUrl": "..."}}
             result_data = output.get("result", {})
             access_token = result_data.get("accessToken")
             instance_url = result_data.get("instanceUrl")
@@ -105,8 +105,7 @@ class SFCLIAuth:
             if not access_token or not instance_url:
                 raise Exception(
                     f"SF CLI response missing required fields. "
-                    f"Got accessToken={bool(access_token)}, instanceUrl={bool(instance_url)}"
-                )
+                    f"Got accessToken={bool(access_token)}, instanceUrl={bool(instance_url)}")
 
             # Update cached values
             self._token = access_token
@@ -115,23 +114,26 @@ class SFCLIAuth:
 
             logger.info(
                 f"Successfully refreshed SF CLI credentials, "
-                f"cached until {self._token_expiry.strftime('%Y-%m-%d %H:%M:%S')}"
-            )
+                f"cached until {self._token_expiry.strftime('%Y-%m-%d %H:%M:%S')}")
 
         except subprocess.TimeoutExpired as e:
-            raise Exception(f"SF CLI command timed out after 120 seconds") from e
+            raise Exception(
+                f"SF CLI command timed out after 120 seconds") from e
         except subprocess.CalledProcessError as e:
             error_output = e.stderr if e.stderr else e.stdout
             raise Exception(
                 f"SF CLI command failed with exit code {e.returncode}. "
                 f"Ensure you've authenticated via: sf org login web --alias {self.org_alias}\n"
-                f"Error output: {error_output[:500]}"
+                f"Error output: {error_output[:500]}") from e
+        except json.JSONDecodeError as e:
+            raise Exception(
+                f"SF CLI returned invalid JSON. "
+                f"Raw output (first 500 chars): {result.stdout[:500]}"
             ) from e
         except FileNotFoundError as e:
             raise Exception(
                 "SF CLI (sf command) not found. "
-                "Install from: https://developer.salesforce.com/tools/salesforcecli"
-            ) from e
+                "Install from: https://developer.salesforce.com/tools/salesforcecli") from e
 
     def _ensure_valid_token(self) -> None:
         """Ensure we have a valid cached token, refreshing if needed."""

--- a/sf_cli_auth.py
+++ b/sf_cli_auth.py
@@ -1,0 +1,165 @@
+"""
+SF CLI authentication provider for datacloud-mcp-query.
+
+Uses the Salesforce CLI (sf command) to obtain access tokens from an authenticated org.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from datetime import datetime, timedelta
+from typing import Optional
+
+# Get logger for this module
+logger = logging.getLogger(__name__)
+
+
+class SFCLIAuth:
+    """
+    Authentication provider that uses SF CLI (sf command) for token management.
+
+    Caches tokens for 5 minutes to reduce subprocess overhead while maintaining freshness.
+    """
+
+    # Token cache duration (5 minutes)
+    CACHE_DURATION_MINUTES = 5
+
+    def __init__(self, org_alias: str):
+        """
+        Initialize SF CLI authentication with the specified org alias.
+
+        Args:
+            org_alias: The SF CLI org alias or username
+
+        Raises:
+            Exception: If SF CLI is not available or org is not authenticated
+        """
+        self.org_alias = org_alias
+        self._token: Optional[str] = None
+        self._instance_url: Optional[str] = None
+        self._token_expiry: Optional[datetime] = None
+
+        logger.info(f"Initializing SF CLI authentication with org: {org_alias}")
+
+        # Validate SF CLI is available
+        if not shutil.which("sf"):
+            raise Exception(
+                "SF CLI (sf command) not found in PATH. "
+                "Install from: https://developer.salesforce.com/tools/salesforcecli"
+            )
+
+        # Test authentication by fetching initial token
+        try:
+            self._refresh_credentials()
+        except Exception as e:
+            raise Exception(
+                f"Failed to authenticate with SF CLI org '{org_alias}'. "
+                f"Ensure you've authenticated via: sf org login web --alias {org_alias}\n"
+                f"Error: {str(e)}"
+            ) from e
+
+    @staticmethod
+    def is_available() -> bool:
+        """
+        Check if SF CLI authentication is configured and available.
+
+        Returns:
+            bool: True if SF_ORG_ALIAS is set and sf command exists
+        """
+        return bool(os.getenv("SF_ORG_ALIAS")) and shutil.which("sf") is not None
+
+
+    def _refresh_credentials(self) -> None:
+        """
+        Refresh credentials by calling SF CLI.
+
+        Raises:
+            Exception: If SF CLI command fails or returns invalid data
+        """
+        logger.info(f"Refreshing SF CLI credentials for org: {self.org_alias}")
+
+        try:
+            # Call SF CLI to get org details with JSON output
+            result = subprocess.run(
+                ["sf", "org", "display", "--target-org", self.org_alias, "--json"],
+                capture_output=True,
+                text=True,
+                timeout=120,  # 2 minute timeout
+                check=True,
+            )
+
+            logger.debug(f"SF CLI command completed, parsing output")
+
+            # Parse JSON output
+            output = json.loads(result.stdout)
+
+            # Extract access token and instance URL
+            # SF CLI output format: {"result": {"accessToken": "...", "instanceUrl": "..."}}
+            result_data = output.get("result", {})
+            access_token = result_data.get("accessToken")
+            instance_url = result_data.get("instanceUrl")
+
+            if not access_token or not instance_url:
+                raise Exception(
+                    f"SF CLI response missing required fields. "
+                    f"Got accessToken={bool(access_token)}, instanceUrl={bool(instance_url)}"
+                )
+
+            # Update cached values
+            self._token = access_token
+            self._instance_url = instance_url
+            self._token_expiry = datetime.now() + timedelta(minutes=self.CACHE_DURATION_MINUTES)
+
+            logger.info(
+                f"Successfully refreshed SF CLI credentials, "
+                f"cached until {self._token_expiry.strftime('%Y-%m-%d %H:%M:%S')}"
+            )
+
+        except subprocess.TimeoutExpired as e:
+            raise Exception(f"SF CLI command timed out after 120 seconds") from e
+        except subprocess.CalledProcessError as e:
+            error_output = e.stderr if e.stderr else e.stdout
+            raise Exception(
+                f"SF CLI command failed with exit code {e.returncode}. "
+                f"Ensure you've authenticated via: sf org login web --alias {self.org_alias}\n"
+                f"Error output: {error_output[:500]}"
+            ) from e
+        except FileNotFoundError as e:
+            raise Exception(
+                "SF CLI (sf command) not found. "
+                "Install from: https://developer.salesforce.com/tools/salesforcecli"
+            ) from e
+
+    def _ensure_valid_token(self) -> None:
+        """Ensure we have a valid cached token, refreshing if needed."""
+        if not self._token_expiry or datetime.now() >= self._token_expiry:
+            self._refresh_credentials()
+
+    def get_token(self) -> str:
+        """
+        Get a valid access token from SF CLI.
+
+        Returns:
+            str: A valid Salesforce access token
+
+        Raises:
+            Exception: If SF CLI authentication fails
+        """
+        self._ensure_valid_token()
+        return self._token
+
+    def get_instance_url(self) -> str:
+        """
+        Get the Salesforce instance URL from SF CLI.
+
+        Returns:
+            str: The Salesforce instance URL
+
+        Raises:
+            Exception: If SF CLI authentication fails
+        """
+        self._ensure_valid_token()
+        return self._instance_url

--- a/sf_cli_auth.py
+++ b/sf_cli_auth.py
@@ -31,11 +31,15 @@ class SFCLIAuth:
         """
         Initialize SF CLI authentication with the specified org alias.
 
+        Credentials are fetched lazily on first use, not during construction,
+        so the MCP server can start quickly without blocking on subprocess calls
+        and also so that credentials are not unncessarily fetched until needed.
+
         Args:
             org_alias: The SF CLI org alias or username
 
         Raises:
-            Exception: If SF CLI is not available or org is not authenticated
+            Exception: If SF CLI binary is not installed
         """
         self.org_alias = org_alias
         self._token: Optional[str] = None
@@ -45,25 +49,15 @@ class SFCLIAuth:
         logger.info(
             f"Initializing SF CLI authentication with org: {org_alias}")
 
-        # Validate SF CLI is available
         if not shutil.which("sf"):
             raise Exception(
                 "SF CLI (sf command) not found in PATH. "
                 "Install from: https://developer.salesforce.com/tools/salesforcecli")
 
-        # Test authentication by fetching initial token
-        try:
-            self._refresh_credentials()
-        except Exception as e:
-            raise Exception(
-                f"Failed to authenticate with SF CLI org '{org_alias}'. "
-                f"Ensure you've authenticated via: sf org login web --alias {org_alias}\n"
-                f"Error: {str(e)}") from e
-
     @staticmethod
-    def is_available() -> bool:
+    def is_configured() -> bool:
         """
-        Check if SF CLI authentication is configured and available.
+        Check if SF CLI authentication is configured.
 
         Returns:
             bool: True if SF_ORG_ALIAS is set and sf command exists

--- a/sf_cli_auth.py
+++ b/sf_cli_auth.py
@@ -16,6 +16,9 @@ from typing import Optional
 # Get logger for this module
 logger = logging.getLogger(__name__)
 
+# Environment variable names
+ENV_SF_ORG_ALIAS = "SF_ORG_ALIAS"
+
 
 class SFCLIAuth:
     """
@@ -62,7 +65,7 @@ class SFCLIAuth:
         Returns:
             bool: True if SF_ORG_ALIAS is set and sf command exists
         """
-        has_alias = bool(os.getenv("SF_ORG_ALIAS"))
+        has_alias = bool(os.getenv(ENV_SF_ORG_ALIAS))
         return has_alias and shutil.which("sf") is not None
 
     def _refresh_credentials(self) -> None:


### PR DESCRIPTION
## Summary

Adds SF CLI authentication as a first-class auth method alongside OAuth PKCE,
with auto-detection, lazy credential fetching, and a clean `AuthProvider`
abstraction. Fully backward compatible with existing OAuth setups.

## Changes

**Authentication**
- New `AuthProvider` protocol (`auth_interface.py`) with `get_token()` /
  `get_instance_url()` / `is_available()`.
- `SFCLIAuth` (`sf_cli_auth.py`): uses `sf org display --json` subprocess,
  caches tokens for 5 min, validates `sf` is on PATH.
- `create_auth_provider()` factory (`auth_factory.py`): auto-detects based on
  env vars with priority SF CLI → OAuth → actionable error message. Warns when
  both are configured.
- Credentials are fetched lazily on first tool call, so the MCP server starts
  fast and doesn't block on auth at import time.
- `OAuthConfig` now raises `OAuthConfigError` instead of `sys.exit` on missing
  config, so callers can fall back cleanly.
- Env var names and default URLs are centralized as module constants
  (`ENV_SF_ORG_ALIAS`, `ENV_SF_CLIENT_*`, `DEFAULT_LOGIN_URL`, etc.).

**Server / Query layer**
- `server.py` uses the auth factory; `list_tables()` and `describe_table()`
  converted to parameterized queries (`:tableFilter`, `:tableName`) instead of
  string interpolation.
- `run_query()` accepts optional `sql_parameters` passed through to the
  Data Cloud API.

**Docs**
- New `QUICK_START.md` with copy-paste Cursor MCP configs.
- New `CLAUDE.md` with architecture overview and auth-method guidance.
- Expanded `README.md`: step-by-step setup, both auth methods side by side,
  auto-detection logic, and a troubleshooting section (including pip-install
  hint for "module not found").
- `requirements.txt` added.

## Auth configuration

| Method  | Env vars                                 |
|---------|------------------------------------------|
| SF CLI  | `SF_ORG_ALIAS`                           |
| OAuth   | `SF_CLIENT_ID`, `SF_CLIENT_SECRET` (+ optional `SF_LOGIN_URL`, `SF_CALLBACK_URL`) |
