### PR TITLE
feat: Add querySettings passthrough to query tool

### DIFF
--- a/connect_api_dc_sql.py
+++ b/connect_api_dc_sql.py
@@ -47,6 +47,7 @@ def run_query(
     dataspace: str = "default",
     workload_name: str | None = "data-360-mcp-query-oss",
     pagination_batch_size: int = 100000,
+    query_settings: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Union[List, str]]:
     """
     Execute a SQL query using the Data Cloud Query Connect API, handling long-running queries
@@ -63,6 +64,9 @@ def run_query(
         dataspace: Data Cloud dataspace name (default: "default")
         workload_name: Workload name for resource management
         pagination_batch_size: Number of rows to fetch per page
+        query_settings: Optional dict of query execution settings passed through as
+            ``querySettings`` in the Data Cloud Query API request body. Example:
+            {"query_timeout": "1800000ms"}
 
     Returns a dictionary containing:
     - 'data': the complete list of rows (aggregated across all pages) or "(empty)" if no rows
@@ -81,6 +85,8 @@ def run_query(
     submit_body: dict = {"sql": sql}
     if sql_parameters:
         submit_body["sqlParameters"] = sql_parameters
+    if query_settings:
+        submit_body["querySettings"] = query_settings
     logger.info(
         f"Submitting SQL query to {url_base}, with params: {common_params}")
 

--- a/server.py
+++ b/server.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -28,14 +29,35 @@ DEFAULT_LIST_TABLE_FILTER = os.getenv('DEFAULT_LIST_TABLE_FILTER', '%')
 DATASPACE_FIELD_DESCRIPTION = "The Data Cloud dataspace name to execute against. Defaults to 'default'."
 
 
-@mcp.tool(description="Executes a SQL query and returns the results")
+@mcp.tool(
+    description=(
+        "Executes a SQL query against Salesforce Data 360 (formerly Data Cloud) and returns the results. "
+        "Data 360 SQL is PostgreSQL-flavored but has its own dialect, supported functions, and constraints. "
+        "For authoritative syntax, supported functions, and semantics, consult the Data 360 SQL Reference: "
+        "https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/dc-sql-reference/data-cloud-sql-context.html"
+    )
+)
 def query(
     sql: str = Field(
-        description="A SQL query in the PostgreSQL dialect make sure to always quote all identifies and use the exact casing. To formulate the query first verify which tables and fields to use through the suggest fields tool (or if it is broken through the list tables / describe tables call). Before executing the tool provide the user a succinct summary (targeted to low code users) on the semantics of the query"),
+        description=(
+            "A SQL query in the Data 360 SQL dialect (PostgreSQL-flavored). Always quote all identifiers "
+            "and preserve their exact casing. Before writing a query, verify the tables and fields to use "
+            "via the suggest fields tool (or, if unavailable, via list_tables / describe_table). "
+            "When in doubt about supported syntax or functions, refer to the Data 360 SQL Reference: "
+            "https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/dc-sql-reference/data-cloud-sql-context.html "
+            "Before executing the tool, provide the user a succinct summary (targeted to low code users) on the semantics of the query."
+        )
+    ),
     dataspace: str = Field(default="default", description=DATASPACE_FIELD_DESCRIPTION),
+    query_settings: Optional[dict[str, str]] = Field(
+        default=None,
+        description="Optional Data Cloud query settings, passed through as-is as 'querySettings' in the Query API request body. Known settings include 'query_timeout' with a duration-suffixed value, e.g. {\"query_timeout\": \"1800000ms\"}. Leave unset to use Data Cloud defaults.",
+    ),
 ):
     # Returns both data and metadata
-    return run_query(auth_provider, sql, dataspace=dataspace)
+    return run_query(
+        auth_provider, sql, dataspace=dataspace, query_settings=query_settings
+    )
 
 
 @mcp.tool(description="Lists the available tables in the database")


### PR DESCRIPTION
Exposes an optional query_settings dict through the query MCP tool run_query(). This is forwarded into the Data Cloud Query API request body as querySettings, enabling per-query overrides such as {"query_timeout": "5000ms"}.