### PR TITLE
fix: make query handlers async to prevent MCP server crashes under concurrent load

### DIFF
--- a/connect_api_dc_sql.py
+++ b/connect_api_dc_sql.py
@@ -1,17 +1,21 @@
 import json
 import logging
-import time
 from typing import Dict, List, Optional, Union
 
-import requests
+import anyio
+import httpx
 
 from auth_interface import AuthProvider
 
 # Get logger for this module
 logger = logging.getLogger(__name__)
 
+# Default per-request HTTP timeout (seconds). Covers connect + read + write.
+# Must be larger than the Data Cloud long-poll wait time (10s) plus headroom.
+_DEFAULT_HTTP_TIMEOUT_S = 120.0
 
-def _handle_error_response(response: requests.Response):
+
+def _handle_error_response(response: httpx.Response):
     if response.status_code >= 300:
         # Parse error message from response
         message = response.text
@@ -35,12 +39,12 @@ def _handle_error_response(response: requests.Response):
         # Raise exception with error message
         raise Exception(
             response.status_code,
-            response.reason,
+            response.reason_phrase,
             message,
         )
 
 
-def run_query(
+async def run_query(
     auth_provider: AuthProvider,
     sql: str,
     sql_parameters: Optional[List[Dict[str, Union[str, int, float, bool]]]] = None,
@@ -52,6 +56,12 @@ def run_query(
     """
     Execute a SQL query using the Data Cloud Query Connect API, handling long-running queries
     and paginated result retrieval.
+
+    This is a native coroutine that uses ``httpx.AsyncClient`` for non-blocking I/O, so it
+    can be awaited from an asyncio/anyio event loop without tying up a worker thread while
+    waiting on the server. ``AuthProvider`` methods are still synchronous; any potentially
+    blocking work they perform (subprocesses, OAuth flows) is offloaded to a worker thread
+    via ``anyio.to_thread.run_sync`` so it does not block the event loop either.
 
     Args:
         auth_provider: Authentication provider (SF CLI, OAuth, etc.)
@@ -72,8 +82,8 @@ def run_query(
     - 'data': the complete list of rows (aggregated across all pages) or "(empty)" if no rows
     - 'metadata': the schema/metadata of the result columns
     """
-    base_url = auth_provider.get_instance_url()
-    token = auth_provider.get_token()
+    base_url = await anyio.to_thread.run_sync(auth_provider.get_instance_url)
+    token = await anyio.to_thread.run_sync(auth_provider.get_token)
 
     headers = {"Authorization": f"Bearer {token}"}
     url_base = base_url + "/services/data/v63.0/ssot/query-sql"
@@ -81,94 +91,99 @@ def run_query(
     if workload_name:
         common_params["workloadName"] = workload_name
 
-    # Step 1: submit the query
     submit_body: dict = {"sql": sql}
     if sql_parameters:
         submit_body["sqlParameters"] = sql_parameters
     if query_settings:
         submit_body["querySettings"] = query_settings
-    logger.info(
-        f"Submitting SQL query to {url_base}, with params: {common_params}")
 
-    submit_response = requests.post(
-        url_base,
-        json=submit_body,
-        params=common_params,
-        headers=headers,
-        timeout=120)
+    async with httpx.AsyncClient(timeout=_DEFAULT_HTTP_TIMEOUT_S) as client:
+        # Step 1: submit the query
+        logger.info(
+            f"Submitting SQL query to {url_base}, with params: {common_params}")
 
-    logger.info(
-        f"Query submission response: status={submit_response.status_code}, elapsed={submit_response.elapsed.total_seconds():.2f}s")
-    _handle_error_response(submit_response)
+        submit_response = await client.post(
+            url_base,
+            json=submit_body,
+            params=common_params,
+            headers=headers,
+        )
 
-    submit_payload = submit_response.json()
-    status_obj = submit_payload.get("status", {})
-    query_id = status_obj.get("queryId") or submit_payload.get("queryId")
-    if not query_id:
-        raise Exception(500, "MissingQueryId",
-                        "Query ID not returned by the API.")
+        logger.info(
+            f"Query submission response: status={submit_response.status_code}, "
+            f"elapsed={submit_response.elapsed.total_seconds():.2f}s")
+        _handle_error_response(submit_response)
 
-    # Collect initial rows and metadata if present
-    rows: list = submit_payload.get("data", []) or []
-    metadata = submit_payload.get("metadata", [])
-    completion = status_obj.get("completionStatus")
-    total_row_count = int(status_obj.get("rowCount"))
+        submit_payload = submit_response.json()
+        status_obj = submit_payload.get("status", {})
+        query_id = status_obj.get("queryId") or submit_payload.get("queryId")
+        if not query_id:
+            raise Exception(500, "MissingQueryId",
+                            "Query ID not returned by the API.")
 
-    # Step 2: poll for completion when needed (long-polling via waitTimeMs)
-    poll_count = 0
-    while completion not in ["Finished", "ResultsProduced"]:
-        poll_count += 1
-        poll_url = f"{url_base}/{query_id}"
-        logger.debug(
-            f"Polling query status (attempt {poll_count}): {poll_url}")
+        # Collect initial rows and metadata if present
+        rows: list = submit_payload.get("data", []) or []
+        metadata = submit_payload.get("metadata", [])
+        completion = status_obj.get("completionStatus")
+        total_row_count = int(status_obj.get("rowCount"))
 
-        poll_params = dict(common_params)
-        # Signal that we want to do long-polling to get best latency for query
-        # end notification and minimize RPC calls
-        poll_params.update({
-            "waitTimeMs": 10000,
-        })
-        poll_response = requests.get(
-            poll_url, params=poll_params, headers=headers, timeout=120)
+        # Step 2: poll for completion when needed (long-polling via waitTimeMs)
+        poll_count = 0
+        while completion not in ["Finished", "ResultsProduced"]:
+            poll_count += 1
+            poll_url = f"{url_base}/{query_id}"
+            logger.debug(
+                f"Polling query status (attempt {poll_count}): {poll_url}")
 
-        logger.debug(
-            f"Poll response: status={poll_response.status_code}, elapsed={poll_response.elapsed.total_seconds():.2f}s")
-        _handle_error_response(poll_response)
-        poll_payload = poll_response.json()
-        completion = poll_payload.get("completionStatus")
-        total_row_count = int(poll_payload.get("rowCount"))
+            poll_params = dict(common_params)
+            # Signal that we want to do long-polling to get best latency for query
+            # end notification and minimize RPC calls
+            poll_params.update({
+                "waitTimeMs": 10000,
+            })
+            poll_response = await client.get(
+                poll_url, params=poll_params, headers=headers)
 
-    # Step 3: retrieve remaining rows via pagination
-    while len(rows) < total_row_count:
-        rows_params = dict(common_params)
-        rows_params.update({
-            "rowLimit": pagination_batch_size,
-            "offset": len(rows),
-            "omitSchema": "true",
-        })
+            logger.debug(
+                f"Poll response: status={poll_response.status_code}, "
+                f"elapsed={poll_response.elapsed.total_seconds():.2f}s")
+            _handle_error_response(poll_response)
+            poll_payload = poll_response.json()
+            completion = poll_payload.get("completionStatus")
+            total_row_count = int(poll_payload.get("rowCount"))
 
-        rows_url = f"{url_base}/{query_id}/rows"
-        logger.debug(
-            f"Fetching rows: offset={rows_params.get('offset')}, limit={rows_params.get('rowLimit')}")
+        # Step 3: retrieve remaining rows via pagination
+        while len(rows) < total_row_count:
+            rows_params = dict(common_params)
+            rows_params.update({
+                "rowLimit": pagination_batch_size,
+                "offset": len(rows),
+                "omitSchema": "true",
+            })
 
-        rows_response = requests.get(
-            rows_url, params=rows_params, headers=headers, timeout=120)
+            rows_url = f"{url_base}/{query_id}/rows"
+            logger.debug(
+                f"Fetching rows: offset={rows_params.get('offset')}, limit={rows_params.get('rowLimit')}")
 
-        logger.debug(
-            f"Rows fetch response: status={rows_response.status_code}, elapsed={rows_response.elapsed.total_seconds():.2f}s")
-        _handle_error_response(rows_response)
+            rows_response = await client.get(
+                rows_url, params=rows_params, headers=headers)
 
-        chunk = rows_response.json()
-        chunk_rows = chunk.get("data", []) or []
-        returned_rows = int(chunk.get("returnedRows", len(chunk_rows)))
+            logger.debug(
+                f"Rows fetch response: status={rows_response.status_code}, "
+                f"elapsed={rows_response.elapsed.total_seconds():.2f}s")
+            _handle_error_response(rows_response)
 
-        if returned_rows == 0:
-            raise Exception(500, "MissingRows",
-                            "Expected rows to be returned, but received 0.")
+            chunk = rows_response.json()
+            chunk_rows = chunk.get("data", []) or []
+            returned_rows = int(chunk.get("returnedRows", len(chunk_rows)))
 
-        rows.extend(chunk_rows)
-        logger.debug(
-            f"Retrieved {returned_rows} rows, total so far: {len(rows)}")
+            if returned_rows == 0:
+                raise Exception(500, "MissingRows",
+                                "Expected rows to be returned, but received 0.")
+
+            rows.extend(chunk_rows)
+            logger.debug(
+                f"Retrieved {returned_rows} rows, total so far: {len(rows)}")
 
     logger.info(f"Query completed: retrieved {len(rows)} total rows")
     return {
@@ -181,6 +196,8 @@ if __name__ == "__main__":
     # Manual smoke test: authenticates and runs a query that spans multiple
     # pagination batches. Expects SF_ORG_ALIAS or SF_CLIENT_ID/SF_CLIENT_SECRET
     # to be set in the environment.
+    import asyncio
+
     from auth_factory import create_auth_provider
 
     logging.basicConfig(
@@ -189,9 +206,12 @@ if __name__ == "__main__":
         datefmt='%Y-%m-%d %H:%M:%S',
     )
 
-    auth_provider = create_auth_provider()
-    result = run_query(
-        auth_provider,
-        "SELECT g::text || rpad(1::text,100) as a, g as b FROM generate_series(1, 40000) g ORDER BY b DESC",
-    )
-    print(f"Rows: {len(result['data'])}, Columns: {len(result['metadata'])}")
+    async def _main():
+        auth_provider = create_auth_provider()
+        result = await run_query(
+            auth_provider,
+            "SELECT g::text || rpad(1::text,100) as a, g as b FROM generate_series(1, 40000) g ORDER BY b DESC",
+        )
+        print(f"Rows: {len(result['data'])}, Columns: {len(result['metadata'])}")
+
+    asyncio.run(_main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@
 pydantic>=2.11.7
 requests>=2.32.4
 rfc3986>=2.0.0
+httpx>=0.27.1
 mcp>=1.13.0

--- a/server.py
+++ b/server.py
@@ -37,7 +37,7 @@ DATASPACE_FIELD_DESCRIPTION = "The Data Cloud dataspace name to execute against.
         "https://developer.salesforce.com/docs/data/data-cloud-query-guide/references/dc-sql-reference/data-cloud-sql-context.html"
     )
 )
-def query(
+async def query(
     sql: str = Field(
         description=(
             "A SQL query in the Data 360 SQL dialect (PostgreSQL-flavored). Always quote all identifiers "
@@ -55,38 +55,36 @@ def query(
     ),
 ):
     # Returns both data and metadata
-    return run_query(
+    return await run_query(
         auth_provider, sql, dataspace=dataspace, query_settings=query_settings
     )
 
 
 @mcp.tool(description="Lists the available tables in the database")
-def list_tables(
+async def list_tables(
     dataspace: str = Field(default="default", description=DATASPACE_FIELD_DESCRIPTION),
 ) -> list[str]:
     sql = "SELECT c.relname AS TABLE_NAME FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c LEFT JOIN pg_catalog.pg_description d ON (c.oid = d.objoid AND d.objsubid = 0 AND d.classoid = 'pg_class'::regclass) WHERE c.relnamespace = n.oid AND c.relname LIKE :tableFilter"
-    result = run_query(
+    result = await run_query(
         auth_provider, sql,
         sql_parameters=[{"name": "tableFilter", "value": DEFAULT_LIST_TABLE_FILTER}],
         dataspace=dataspace,
     )
-    # Extract data from the result dictionary
     data = result.get("data", [])
     return [x[0] for x in data]
 
 
 @mcp.tool(description="Describes the columns of a table")
-def describe_table(
+async def describe_table(
     table: str = Field(description="The table name"),
     dataspace: str = Field(default="default", description=DATASPACE_FIELD_DESCRIPTION),
 ) -> list[str]:
     sql = "SELECT a.attname FROM pg_catalog.pg_namespace n JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid) JOIN pg_catalog.pg_attribute a ON (a.attrelid = c.oid) JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid) LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid = def.adrelid AND a.attnum = def.adnum) LEFT JOIN pg_catalog.pg_description dsc ON (c.oid = dsc.objoid AND a.attnum = dsc.objsubid) LEFT JOIN pg_catalog.pg_class dc ON (dc.oid = dsc.classoid AND dc.relname = 'pg_class') LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace = dn.oid AND dn.nspname = 'pg_catalog') WHERE a.attnum > 0 AND NOT a.attisdropped AND c.relname = :tableName"
-    result = run_query(
+    result = await run_query(
         auth_provider, sql,
         sql_parameters=[{"name": "tableName", "value": table}],
         dataspace=dataspace,
     )
-    # Extract data from the result dictionary
     data = result.get("data", [])
     return [x[0] for x in data]
 


### PR DESCRIPTION
Concurrent tool calls blocked FastMCP's worker threads on synchronous `requests` I/O, opening a timing window where `stdio_server.stdin_reader` raised an uncaught `anyio.BrokenResourceError` and killed the MCP server process. This reliably reproduced with an 8-way parallel burst of `query()` calls — including a malformed `query_settings.query_timeout` value — which terminated the whole MCP server with `MCP error -32000: Connection closed`.

Convert `run_query` to a coroutine using `httpx.AsyncClient` and mark the `query` / `list_tables` / `describe_table` handlers `async def`, so all in-flight queries cooperatively share the event loop. `AuthProvider` stays sync (the hot path is a cached-token lookup) and is awaited via `anyio.to_thread.run_sync` so its occasional cold path (SF CLI subprocess, OAuth flow) still doesn't block the event loop.

Also add `httpx` to `requirements.txt` as an explicit dependency (previously transitive via `mcp`).